### PR TITLE
Implement to do list

### DIFF
--- a/src/components/panels/health/health-panel.tsx
+++ b/src/components/panels/health/health-panel.tsx
@@ -115,6 +115,15 @@ export const HeroHealthPanel = (props: HeroProps) => {
 		}
 	};
 
+	const setReactionUsed = (value: boolean) => {
+		const copy = Utils.copy(hero);
+		copy.state.reactionUsed = value;
+		setHero(copy);
+		if (props.onChange) {
+			props.onChange(copy);
+		}
+	};
+
 	const setDefeated = (value: boolean) => {
 		const copy = Utils.copy(hero);
 		copy.state.defeated = value;
@@ -184,6 +193,10 @@ export const HeroHealthPanel = (props: HeroProps) => {
 					recoveryValue: HeroLogic.getRecoveryValue(hero),
 					setValue: setRecoveriesUsed,
 					spendRecovery: spendRecovery
+				}}
+				reaction={{
+					value: hero.state.reactionUsed,
+					setValue: setReactionUsed
 				}}
 				hidden={{
 					value: hero.state.hidden,
@@ -295,6 +308,15 @@ export const MonsterHealthPanel = (props: MonsterProps) => {
 		}
 	};
 
+	const setReactionUsed = (value: boolean) => {
+		const copy = Utils.copy(monster);
+		copy.state.reactionUsed = value;
+		setMonster(copy);
+		if (props.onChange) {
+			props.onChange(copy);
+		}
+	};
+
 	const setDefeated = (value: boolean) => {
 		const copy = Utils.copy(monster);
 		copy.state.defeated = value;
@@ -373,6 +395,10 @@ export const MonsterHealthPanel = (props: MonsterProps) => {
 						}
 						: undefined
 				}
+				reaction={{
+					value: monster.state.reactionUsed,
+					setValue: setReactionUsed
+				}}
 				hidden={{
 					value: monster.state.hidden,
 					setValue: setHidden
@@ -455,6 +481,15 @@ export const MinionGroupHealthPanel = (props: MinionGroupProps) => {
 		}
 	};
 
+	const setReactionUsed = (value: boolean) => {
+		const copy = Utils.copy(slot);
+		copy.state.reactionUsed = value;
+		setSlot(copy);
+		if (props.onChange) {
+			props.onChange(copy);
+		}
+	};
+
 	const addCondition = (condition: Condition) => {
 		const copy = Utils.copy(slot);
 		copy.state.conditions.push(condition);
@@ -499,6 +534,10 @@ export const MinionGroupHealthPanel = (props: MinionGroupProps) => {
 					setValue: setStaminaDamage,
 					takeDamage: takeDamage,
 					heal: heal
+				}}
+				reaction={{
+					value: slot.state.reactionUsed,
+					setValue: setReactionUsed
 				}}
 				defeated={{
 					value: slot.state.defeated,
@@ -550,6 +589,10 @@ interface Props {
 		setValue: (value: number) => void;
 		spendRecovery: () => void;
 	}
+	reaction?: {
+		value: boolean;
+		setValue: (value: boolean) => void;
+	};
 	hidden?: {
 		value: boolean;
 		setValue: (value: boolean) => void;
@@ -771,6 +814,9 @@ const HealthPanel = (props: Props) => {
 			if (props.hidden && props.hidden.value) {
 				tags.push('Hidden');
 			}
+			if (props.reaction && props.reaction.value) {
+				tags.push('Reaction');
+			}
 			if (props.captain && props.captain.captainID) {
 				const captain = props.captain.candidates.find(m => m.id === props.captain!.captainID);
 				if (captain) {
@@ -852,7 +898,7 @@ Your allies can help you spend Recoveries in combat, and you can spend Recoverie
 						: null
 				}
 				{
-					props.showToggles && (props.hidden || props.defeated || props.captain) ?
+					props.showToggles && (props.hidden || props.defeated || props.captain || props.reaction) ?
 						<>
 							<Flex align='center' justify='space-evenly' gap={10} style={{ margin: '10px 0' }}>
 								{
@@ -867,6 +913,22 @@ Your allies can help you spend Recoveries in combat, and you can spend Recoverie
 												]}
 												value={props.hidden.value}
 												onChange={props.hidden.setValue}
+											/>
+										</div>
+										: null
+								}
+								{
+									props.reaction ?
+										<div className='toggle-button'>
+											<div className='toggle-button-label'>Reaction</div>
+											<Segmented
+												block={true}
+												options={[
+													{ value: true, label: 'Used' },
+													{ value: false, label: 'Available' }
+												]}
+												value={props.reaction.value}
+												onChange={props.reaction.setValue}
 											/>
 										</div>
 										: null

--- a/src/data/heroes/dwarf-fury.ts
+++ b/src/data/heroes/dwarf-fury.ts
@@ -2200,6 +2200,7 @@ export const dwarfFury = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/data/heroes/high-elf-tactician.ts
+++ b/src/data/heroes/high-elf-tactician.ts
@@ -2067,6 +2067,7 @@ export const highElfTactician = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/data/heroes/human-censor.ts
+++ b/src/data/heroes/human-censor.ts
@@ -2268,6 +2268,7 @@ export const humanCensor = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/data/heroes/human-null.ts
+++ b/src/data/heroes/human-null.ts
@@ -2469,6 +2469,7 @@ export const humanNull = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/data/heroes/human-talent.ts
+++ b/src/data/heroes/human-talent.ts
@@ -2806,6 +2806,7 @@ export const humanTalent = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/data/heroes/orc-conduit.ts
+++ b/src/data/heroes/orc-conduit.ts
@@ -2243,6 +2243,7 @@ export const orcConduit = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/data/heroes/polder-elementalist.ts
+++ b/src/data/heroes/polder-elementalist.ts
@@ -2993,6 +2993,7 @@ export const polderElementalist = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/data/heroes/polder-shadow.ts
+++ b/src/data/heroes/polder-shadow.ts
@@ -2415,6 +2415,7 @@ export const polderShadow = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/data/heroes/wode-elf-troubadour.ts
+++ b/src/data/heroes/wode-elf-troubadour.ts
@@ -2711,6 +2711,7 @@ export const wodeElfTroubadour = {
 		projects: [],
 		controlledSlots: [],
 		notes: '',
+		reactionUsed: false,
 		encounterState: 'ready',
 		hidden: false,
 		defeated: false

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -102,6 +102,7 @@ export class FactoryLogic {
 			projects: [],
 			controlledSlots: [],
 			notes: '',
+			reactionUsed: false,
 			encounterState: 'ready',
 			hidden: false,
 			defeated: false

--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -1,5 +1,6 @@
 import { AbilityUpdateLogic } from './ability-update-logic';
 import { FeatureType } from '../../enums/feature-type';
+import { FeatureChoiceData } from '../../models/feature';
 import { FeatureUpdateLogic } from './feature-update-logic';
 import { Hero } from '../../models/hero';
 import { HeroLogic } from '../hero-logic';
@@ -23,6 +24,14 @@ export class HeroUpdateLogic {
 
 		if (hero.ancestry) {
 			hero.ancestry.features.forEach(FeatureUpdateLogic.updateFeature);
+
+			// Revenant: 3 ancestry points if small, otherwise 2
+			if (hero.ancestry.id === 'ancestry-revenant') {
+				const traits = hero.ancestry.features.find(f => f.id === 'revenant-feature-4');
+				if (traits && traits.type === FeatureType.Choice) {
+					(traits.data as unknown as FeatureChoiceData).count = (HeroLogic.getSize(hero).mod === 'S') ? 3 : 2;
+				}
+			}
 		}
 
 		if (hero.career) {
@@ -104,6 +113,11 @@ export class HeroUpdateLogic {
 
 		if (hero.state.encounterState === undefined) {
 			hero.state.encounterState = 'ready';
+		}
+
+		const heroStateUntyped = hero.state as unknown as { reactionUsed?: boolean };
+		if (heroStateUntyped.reactionUsed === undefined) {
+			hero.state.reactionUsed = false;
 		}
 
 		if (hero.state.defeated === undefined) {

--- a/src/models/hero.ts
+++ b/src/models/hero.ts
@@ -26,6 +26,7 @@ export interface HeroState {
 	projects: Project[];
 	controlledSlots: EncounterSlot[];
 	notes: string;
+	reactionUsed: boolean;
 	hidden: boolean;
 	encounterState: 'ready' | 'current' | 'finished';
 	defeated: boolean;


### PR DESCRIPTION
Implements "Used Reaction" toggles for combatants and adjusts Revenant ancestry points based on size, fulfilling two to-do list items.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fa05dc4-7bb6-4199-ac9d-721fbeb9a0df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fa05dc4-7bb6-4199-ac9d-721fbeb9a0df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

